### PR TITLE
Implement offer comparison ranking tool

### DIFF
--- a/mcp-servers/clientside/main.py
+++ b/mcp-servers/clientside/main.py
@@ -37,7 +37,7 @@ def send_disclosure(client_email: str, disclosure_type: str, transaction_id: str
 
 @server.tool
 def compare_offers(offers: list):
-    """Compare multiple offers for a property"""
+    """Compare and rank multiple offers for a property"""
     return client_tools.compare_offers(offers)
 
 if __name__ == "__main__":

--- a/mcp-servers/clientside/tools/offer_utils.py
+++ b/mcp-servers/clientside/tools/offer_utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Dict
+
+
+def sentiment_score(text: str) -> float:
+    """Very naive sentiment score based on positive keywords."""
+    if not text:
+        return 0.5
+    positive_words = ["love", "care", "great", "wonderful", "amazing"]
+    text_l = text.lower()
+    for word in positive_words:
+        if word in text_l:
+            return 1.0
+    return 0.5
+
+
+def rank_offers(offers: List[Dict]) -> List[Dict]:
+    """Rank offers using weighted scoring."""
+    if not offers:
+        return []
+
+    max_price = max(o.get("price", 0) for o in offers) or 1
+    max_cont = max(len(o.get("contingencies", [])) for o in offers)
+    dates = [datetime.fromisoformat(o["close_date"]) for o in offers if o.get("close_date")]
+    min_date = min(dates)
+    max_date = max(dates)
+    date_range = (max_date - min_date).days or 1
+
+    ranked = []
+    for offer in offers:
+        price_norm = offer.get("price", 0) / max_price
+        cont_norm = 1 - (len(offer.get("contingencies", [])) / (max_cont or 1))
+        close_dt = datetime.fromisoformat(offer["close_date"]) if offer.get("close_date") else max_date
+        closing_norm = 1 - ((close_dt - min_date).days / date_range)
+        sentiment = sentiment_score(offer.get("buyer_letter", ""))
+
+        score = (
+            price_norm * 0.5
+            + cont_norm * 0.3
+            + closing_norm * 0.15
+            + sentiment * 0.05
+        ) * 100
+
+        ranked_offer = dict(offer)
+        ranked_offer["score"] = round(score, 1)
+        ranked.append(ranked_offer)
+
+    ranked.sort(key=lambda x: x["score"], reverse=True)
+    return ranked

--- a/test-mcp-servers.py
+++ b/test-mcp-servers.py
@@ -6,6 +6,14 @@ import asyncio
 import httpx
 import json
 from typing import Dict, Any
+from pathlib import Path
+
+# Allow importing client tools directly for local function tests
+sys_path_added = str(Path(__file__).parent / "mcp-servers" / "clientside" / "tools")
+import sys
+if sys_path_added not in sys.path:
+    sys.path.append(sys_path_added)
+from client_tools import ClientTools
 
 
 async def test_mcp_server(name: str, port: int) -> Dict[str, Any]:
@@ -61,6 +69,44 @@ async def test_generate_comps_endpoint():
         return False
 
 
+def test_compare_offers_function() -> None:
+    """Test the compare_offers logic with dummy data."""
+    client_tools = ClientTools()
+    offers = [
+        {
+            "price": 985000,
+            "contingencies": ["inspection", "loan"],
+            "close_date": "2025-08-01",
+            "buyer_letter": "We love this home and will care for it forever!",
+        },
+        {
+            "price": 990000,
+            "contingencies": [],
+            "close_date": "2025-07-15",
+            "buyer_letter": "No buyer letter.",
+        },
+        {
+            "price": 970000,
+            "contingencies": ["loan"],
+            "close_date": "2025-07-28",
+            "buyer_letter": "My daughter grew up in this neighborhood.",
+        },
+    ]
+
+    result = client_tools.compare_offers(offers)
+    ranked = result.get("data", {}).get("ranked_offers", [])
+
+    print("\n✅ compare_offers function executed")
+    print("📋 Ranked Offers:")
+    for offer in ranked:
+        print(offer)
+
+    if ranked and ranked[0]["price"] == 990000:
+        print("✅ Ranking looks correct")
+    else:
+        print("❌ Ranking may be incorrect")
+
+
 async def main():
     """Test all MCP servers"""
     print("🧪 Testing EstateWise MCP Servers")
@@ -111,4 +157,6 @@ async def main():
 
 if __name__ == "__main__":
     success = asyncio.run(main())
-    exit(0 if success else 1) 
+    print("\n🔍 Testing compare_offers function...")
+    test_compare_offers_function()
+    exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- implement weighted ranking logic for offers in `client_tools`
- expose new compare_offers tool
- add helper `offer_utils` for scoring
- expand tests with compare_offers demo

## Testing
- `python test_generate_comps.py`
- `python test-mcp-servers.py`

------
https://chatgpt.com/codex/tasks/task_e_6877d5446b48832a88a4b75a68c026c3